### PR TITLE
Fix bad characters

### DIFF
--- a/docs/2.2/configEditor.html
+++ b/docs/2.2/configEditor.html
@@ -1,6 +1,6 @@
 <h2>Configuration Editor</h2>
 
-<p>The Configuration Editor is displayed using the Project | Configuration | Edit… menu item and
+<p>The Configuration Editor is displayed using the Project | Configuration | Edit... menu item and
 supports the following operations:</p>
 
 <div class="screenshot-right">
@@ -15,7 +15,7 @@ is made active.</p>
 <h3>Rename</h3>
 <p>Rename the selected configuration.</p>
 
-<h3>Add…</h3>
+<h3>Add...</h3>
 <p>Add a new configuration. The Add
 Configuration dialog allows specifying an
 existing configuration to use as a template.</p>


### PR DESCRIPTION
Just converting the project editor docs to markdown, there's a couple of bad characters in the 2.X version.