### PR TITLE
Added the NUnit Console to the downloads

### DIFF
--- a/download.html
+++ b/download.html
@@ -7,12 +7,16 @@
     <td>October 3, 2016</td>
   </tr>
   <tr>
-    <td><a href="https://github.com/nunit/nunitv2/releases/latest">NUnit 2.6.4</a></td>
-    <td>December 16, 2014</td>
+    <td><a href="https://github.com/nunit/nunit-console/releases/latest">NUnit Console 3.5</a></td>
+    <td>October 11, 2016</td>
   </tr>
   <tr>
     <td><a href="https://github.com/nunit/nunit3-vs-adapter/releases/latest">NUnit Test Adapter 3.4.1</a></td>
     <td>August 3, 2016</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/nunit/nunitv2/releases/latest">NUnit 2.6.4</a></td>
+    <td>December 16, 2014</td>
   </tr>
   <tr>
     <td><a href="https://github.com/nunit/nunit-vs-adapter/releases/latest">NUnit Test Adapter 2.0</a></td>


### PR DESCRIPTION
Fixes #47 

I've pushed this change live. I can push any requested changes, but I wanted to get this live since we've had a few questions lately on where the console was.