### PR TITLE
nunit.xamarin 3.6.1 release

### DIFF
--- a/download.html
+++ b/download.html
@@ -15,6 +15,14 @@
     <td>August 3, 2016</td>
   </tr>
   <tr>
+    <td><a href="https://github.com/nunit/nunit.xamarin/releases/latest">NUnit Xamarin Runners 3.6.1</a></td>
+    <td>March 14, 2017</td>
+  </tr>
+</table>
+
+<table class="downloads">
+  <tr><th colspan="2">Latest NUnit 2 Releases</th></tr>
+  <tr>
     <td><a href="https://github.com/nunit/nunitv2/releases/latest">NUnit 2.6.4</a></td>
     <td>December 16, 2014</td>
   </tr>

--- a/home.html
+++ b/home.html
@@ -64,6 +64,15 @@
 <div id="news">
     <h4>Recent News</h4>
 
+    <p><b>NUnit Xamarin Runners 3.6.1 Released</b></p>
+      <p>An update to the NUnit Xamarin runners has been released. This update includes a number of new features
+      including XML output, results over TCP, and improvements for integration with CI systems.</p>
+
+      <p>Install the runners from <a href="https://www.nuget.org/packages/nunit.xamarin/">NuGet</a>
+       or by searching for the package <b>nunit.xamarin</b>.</p>
+
+      <p>For more information, see the <a href="https://github.com/nunit/nunit.xamarin">GitHub</a> page.</p>
+
     <p><b>NUnit Console 3.6.1 Hotfix Release</b></br>
 	  <p>This is a hotfix release of the console runner that addresses critical issues found in the 3.6 release.</p>
 
@@ -110,16 +119,6 @@
       <p>Supports Visual Studio 2012 through 2015.</p>
 
       <p>Available from the VS Gallery.
-
-    <p><b>NUnit Xamarin Runners Released</b><br>
-      Adds support for running NUnit 3.0 unit tests on Xamarin.</p>
-
-      <p>Supported platforms - Android, iOS, Windows Phone 8.1 and Window 10 Universal Apps.</p>
-
-      <p>Install the runners from <a href="https://www.nuget.org/packages/nunit.xamarin/">NuGet</a>
-       or by searching for the package <b>nunit.xamarin</b>.</p>
-
-      <p>For more information, see the <a href="https://github.com/nunit/nunit.xamarin">GitHub</a> page.</p>
 
 	  <p><b>NUnit 2.6.4 Released</b><br>
 	  This fixes a few bugs in NUnit 2.6.3 and adds checks to ensure that tests


### PR DESCRIPTION
**NOT READY TO MERGE** - This will be for @rprouse to merge, after reviewing and releasing https://github.com/nunit/nunit.xamarin/pull/90 (which I hope to complete the work for tonight!)

-------------------

I know historically we've only put the 'core products' on the download page - but I thought it might give the Xamarin runners a little more exposure, adding them here. What do people think - @rprouse @nunit/core-team?